### PR TITLE
Define the repository architecture corpus

### DIFF
--- a/AI_CONSTITUTION.md
+++ b/AI_CONSTITUTION.md
@@ -1,0 +1,68 @@
+---
+schema: aether.architecture-document/v1
+id: organization-github-ai-constitution
+title: Ego Hygiene .github Ai Constitution
+kind: architecture-document
+version: 0.1.0
+status: provisional
+owners:
+  - egohygiene
+created: 2026-08-19
+updated: 2026-08-19
+governed_by:
+  - architecture-ai-constitution
+depends_on:
+  - organization-github-purpose
+  - organization-github-vision
+  - organization-github-principles
+  - organization-github-epistemology
+related:
+  - organization-github-pillars
+  - organization-github-manifesto
+  - organization-github-ontology
+  - organization-github-personal-model
+supersedes: []
+---
+
+# Ego Hygiene .github AI Constitution
+
+## Scope and authority
+
+This constitution governs AI systems that inspect, author, validate, or operate on Ego Hygiene .github. Applicable law and platform safety requirements, organization policy, repository policy, accepted architecture, and explicit task authority take precedence over local prompts or model defaults.
+
+Humans retain override authority and responsibility for consequential decisions.
+
+## Constitutional commitments
+
+- Use the least privilege and smallest data scope needed.
+- Distinguish observations, inference, proposals, assumptions, and decisions.
+- Never fabricate completion, validation, provenance, or authority.
+- Prefer reversible, reviewable work under uncertainty.
+- Preserve privacy, secrets, licensing, and safety boundaries.
+- Surface conflicts and missing evidence instead of smoothing them over.
+- Keep significant actions attributable and reviewable.
+
+## Action classes
+
+| Class | Examples | Default authority |
+| --- | --- | --- |
+| Read-only | Inspect repository evidence | Allowed within task scope |
+| Drafting | Produce documents, plans, or uncommitted changes | Allowed and labeled draft |
+| Reversible modification | Change a branch or isolated workspace | Requires granted modification scope |
+| External communication | Publish, comment, notify, or open changes | Requires explicit publication authority |
+| High impact | Production, financial, legal, destructive, secret-bearing | Requires explicit approval and safeguards |
+
+## Escalation
+
+Pause when authority is ambiguous, instructions conflict, evidence is insufficient for a material claim, personal or secret data may be exposed, or the action exceeds the approved risk class.
+
+## Repository-specific boundary
+
+AI may assist Ego Hygiene .github's systems—Organization profile, Community health defaults, Issue and pull-request intake, Agent instruction projection, Coordination queue—but capability does not grant permission to operate them consequentially.
+
+## Evidence and uncertainty
+
+- **Observed:** The repository README establishes the intended boundary as the organization-facing GitHub profile, public defaults, contribution entry points, and fallback coordination surface; significant implementation remains incomplete.
+- **Decided for this draft:** The repository owns the bounded concern described here and participates through versioned contracts.
+- **Proposed:** Target systems and later roadmap phases remain proposals until accepted and implemented.
+- **Open question:** Which parts of this draft should become active in the first independently versioned release?

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,84 @@
+---
+schema: aether.architecture-document/v1
+id: organization-github-architecture
+title: Ego Hygiene .github Architecture
+kind: architecture-document
+version: 0.1.0
+status: provisional
+owners:
+  - egohygiene
+created: 2026-08-19
+updated: 2026-08-19
+governed_by:
+  - architecture-architecture
+depends_on:
+  - organization-github-foundations
+  - organization-github-system
+related:
+  - organization-github-purpose
+  - organization-github-vision
+  - organization-github-principles
+  - organization-github-pillars
+supersedes: []
+---
+
+# Ego Hygiene .github Architecture
+
+## Purpose and scope
+
+Ego Hygiene .github uses a layered, contract-driven architecture. This document owns structural boundaries, dependency direction, integration rules, and current-to-target evolution. Logical responsibilities remain canonical in [SYSTEM.md](SYSTEM.md).
+
+## Layer model
+
+1. **Intent and contracts** — identity, policy, specifications, schemas, and accepted decisions.
+2. **Domain** — canonical concepts and pure domain behavior.
+3. **Application** — planning, orchestration, use cases, and state transitions.
+4. **Adapters** — filesystems, providers, frameworks, renderers, and external tools.
+5. **Interfaces** — CLI, library, site, reports, generated artifacts, and automation contracts.
+6. **Evidence** — tests, diagnostics, provenance, manifests, and health projections.
+
+Dependencies point inward toward stable contracts and domain behavior. External details do not become canonical domain truth.
+
+## Structural view
+
+```mermaid
+flowchart LR
+  S1[Organization profile]
+  S2[Community health defaults]
+  S3[Issue and pull-request intake]
+  S4[Agent instruction projection]
+  S5[Coordination queue]
+  S1 --> S2
+  S2 --> S3
+  S3 --> S4
+  S4 --> S5
+  S5 --> S6
+```
+
+The diagram is conceptual. [SYSTEM.md](SYSTEM.md) remains authoritative for responsibilities and implementation evidence determines current availability.
+
+## Dependency rules
+
+- Sibling domain capabilities integrate through versioned public contracts, not direct access to internals.
+- Generated artifacts never become the canonical source unless an accepted decision explicitly changes ownership.
+- Provider and platform adapters depend on application ports; core behavior does not depend on a provider implementation.
+- Read, plan, apply, verify, publish, and recover remain separate authority boundaries when consequential.
+- Cross-repository references use releases, immutable commits, schemas, packages, or documented APIs rather than mutable default-branch assumptions.
+
+## Ecosystem interfaces
+
+- Hygiene control plane
+- Empathy baseline
+- Relay workflows
+- Aether agent contracts
+
+## Deployment and portability
+
+The architecture favors independently usable local and self-hosted operation. Optional managed services may add availability, collaboration, support, and hosted infrastructure without becoming the canonical holder of portable state.
+
+## Evidence and uncertainty
+
+- **Observed:** The repository README establishes the intended boundary as the organization-facing GitHub profile, public defaults, contribution entry points, and fallback coordination surface; significant implementation remains incomplete.
+- **Decided for this draft:** The repository owns the bounded concern described here and participates through versioned contracts.
+- **Proposed:** Target systems and later roadmap phases remain proposals until accepted and implemented.
+- **Open question:** Which parts of this draft should become active in the first independently versioned release?

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,0 +1,82 @@
+---
+schema: aether.architecture-document/v1
+id: organization-github-decisions
+title: Ego Hygiene .github Decisions
+kind: architecture-document
+version: 0.1.0
+status: provisional
+owners:
+  - egohygiene
+created: 2026-08-19
+updated: 2026-08-19
+governed_by:
+  - architecture-decisions
+depends_on:
+  - organization-github-principles
+  - organization-github-epistemology
+  - organization-github-foundations
+  - organization-github-system
+  - organization-github-architecture
+related:
+  - organization-github-purpose
+  - organization-github-vision
+  - organization-github-pillars
+  - organization-github-manifesto
+supersedes: []
+---
+
+# Ego Hygiene .github Decisions
+
+## Purpose
+
+This document preserves significant accepted architectural choices and their rationale. Issues coordinate work, proposals explore alternatives, and this file records decisions that constrain future implementation.
+
+## Governance
+
+Do not rewrite historical context to fit current understanding. Amend a record for corrections that do not change meaning; supersede it with a new record when the decision changes materially.
+
+## Index
+
+- ADR-001: Keep ecosystem architecture canonical in Hygiene
+- ADR-002: Use this repository as the organization-facing inbox and defaults surface
+- ADR-003: Avoid duplicating implementation libraries
+
+## ADR-001: Keep ecosystem architecture canonical in Hygiene
+
+- **Status:** Accepted as the current architectural direction
+- **Date:** 2026-08-19
+- **Context:** Repository evidence and ecosystem ownership require an explicit durable boundary.
+- **Decision:** Keep ecosystem architecture canonical in Hygiene.
+- **Consequences:** The choice improves ownership and predictability while requiring maintained contracts, validation, and migration discipline.
+- **Reconsider when:** New evidence shows that the boundary prevents standalone usefulness, safety, portability, or maintainability.
+
+## ADR-002: Use this repository as the organization-facing inbox and defaults surface
+
+- **Status:** Accepted as the current architectural direction
+- **Date:** 2026-08-19
+- **Context:** Repository evidence and ecosystem ownership require an explicit durable boundary.
+- **Decision:** Use this repository as the organization-facing inbox and defaults surface.
+- **Consequences:** The choice improves ownership and predictability while requiring maintained contracts, validation, and migration discipline.
+- **Reconsider when:** New evidence shows that the boundary prevents standalone usefulness, safety, portability, or maintainability.
+
+## ADR-003: Avoid duplicating implementation libraries
+
+- **Status:** Accepted as the current architectural direction
+- **Date:** 2026-08-19
+- **Context:** Repository evidence and ecosystem ownership require an explicit durable boundary.
+- **Decision:** Avoid duplicating implementation libraries.
+- **Consequences:** The choice improves ownership and predictability while requiring maintained contracts, validation, and migration discipline.
+- **Reconsider when:** New evidence shows that the boundary prevents standalone usefulness, safety, portability, or maintainability.
+
+## Open decisions
+
+- Release and compatibility policy for the first stable version.
+- Exact self-hosted, managed, and organization-integrated deployment boundaries.
+- Which target systems must exist before the architecture status may become active.
+
+## Evidence and uncertainty
+
+- **Observed:** The repository README establishes the intended boundary as the organization-facing GitHub profile, public defaults, contribution entry points, and fallback coordination surface; significant implementation remains incomplete.
+- **Decided for this draft:** The repository owns the bounded concern described here and participates through versioned contracts.
+- **Proposed:** Target systems and later roadmap phases remain proposals until accepted and implemented.
+- **Open question:** Which parts of this draft should become active in the first independently versioned release?

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,59 @@
+---
+schema: aether.architecture-document/v1
+id: organization-github-design
+title: Ego Hygiene .github Design
+kind: architecture-document
+version: 0.1.0
+status: provisional
+owners:
+  - egohygiene
+created: 2026-08-19
+updated: 2026-08-19
+governed_by:
+  - architecture-design
+depends_on:
+  - organization-github-purpose
+  - organization-github-vision
+  - organization-github-principles
+  - organization-github-personal-model
+related:
+  - organization-github-pillars
+  - organization-github-manifesto
+  - organization-github-epistemology
+  - organization-github-ai-constitution
+supersedes: []
+---
+
+# Ego Hygiene .github Design
+
+## Design philosophy
+
+Ego Hygiene .github should feel welcoming, concise, legible, and unmistakably organization-wide. Experience quality includes terminal, documentation, automation, generated artifacts, APIs, and recovery—not only graphical interfaces.
+
+## Intended qualities
+
+- **Orientation:** people can tell where they are, what is known, and what happens next.
+- **Agency:** consequential choices are previewable, interruptible, and reversible where practical.
+- **Truthfulness:** uncertainty, partial coverage, cost, and limitations remain visible.
+- **Progressive disclosure:** simple journeys remain simple while evidence and advanced control stay reachable.
+- **Continuity:** terms, states, commands, and visual language agree across surfaces.
+- **Care:** accessibility, privacy, cognitive load, and recovery are baseline constraints.
+
+## Core journey
+
+The default journey is understand → configure → preview → act within authority → validate → inspect evidence → recover or continue. Read-only exploration remains available before commitment.
+
+## Failure experience
+
+Failures state what happened, what did not happen, whether partial output is safe, where evidence lives, and the smallest reliable recovery step. They never blame the person.
+
+## Accessibility
+
+Primary information is not encoded only by color, motion, iconography, or spatial position. Interfaces support keyboard access, meaningful focus, semantic structure, reduced motion, readable contrast, and plain-language alternatives.
+
+## Evidence and uncertainty
+
+- **Observed:** The repository README establishes the intended boundary as the organization-facing GitHub profile, public defaults, contribution entry points, and fallback coordination surface; significant implementation remains incomplete.
+- **Decided for this draft:** The repository owns the bounded concern described here and participates through versioned contracts.
+- **Proposed:** Target systems and later roadmap phases remain proposals until accepted and implemented.
+- **Open question:** Which parts of this draft should become active in the first independently versioned release?

--- a/DESIGN_SYSTEM.md
+++ b/DESIGN_SYSTEM.md
@@ -1,0 +1,70 @@
+---
+schema: aether.architecture-document/v1
+id: organization-github-design-system
+title: Ego Hygiene .github Design System
+kind: architecture-document
+version: 0.1.0
+status: provisional
+owners:
+  - egohygiene
+created: 2026-08-19
+updated: 2026-08-19
+governed_by:
+  - architecture-design-system
+depends_on:
+  - organization-github-personal-model
+  - organization-github-design
+related:
+  - organization-github-purpose
+  - organization-github-vision
+  - organization-github-principles
+  - organization-github-pillars
+supersedes: []
+---
+
+# Ego Hygiene .github Design System
+
+## Purpose and scope
+
+This document defines reusable semantic language for Ego Hygiene .github's documentation, terminal output, diagrams, reports, sites, and future interactive surfaces. It does not freeze a framework, component library, or final visual identity.
+
+## Semantic roles
+
+| Role | Meaning |
+| --- | --- |
+| Canvas | Primary quiet background or base surface |
+| Surface | Grouped content or bounded interaction area |
+| Primary | Main action or navigational emphasis |
+| Information | Neutral context or observation |
+| Success | Completed and verified state |
+| Caution | Review required; safe to pause |
+| Danger | Destructive, security, privacy, or irreversible risk |
+| Unknown | Missing, unavailable, partial, or unverified state |
+
+## Status vocabulary
+
+Use the states observed, planned, running, partial, verified, failed, blocked, and unknown consistently. Never present partial or unknown as success.
+
+## Content and interaction
+
+- Use verbs that describe the actual operation.
+- Put scope and consequence before confirmation.
+- Keep destructive actions visually and textually distinct.
+- Pair errors with recovery and evidence locations.
+- Preserve stable identifiers in machine-readable output.
+- Respect reduced-motion and no-color contexts.
+
+## Components and projections
+
+Canonical patterns include command help, progress state, evidence table, decision card, plan preview, validation summary, architecture node, and recovery prompt. Concrete tokens and components are downstream projections maintained by the owning surface.
+
+## Visual direction
+
+The expression should remain welcoming, concise, legible, and unmistakably organization-wide while allowing product-specific identity to vary inside Ego Hygiene's broader family.
+
+## Evidence and uncertainty
+
+- **Observed:** The repository README establishes the intended boundary as the organization-facing GitHub profile, public defaults, contribution entry points, and fallback coordination surface; significant implementation remains incomplete.
+- **Decided for this draft:** The repository owns the bounded concern described here and participates through versioned contracts.
+- **Proposed:** Target systems and later roadmap phases remain proposals until accepted and implemented.
+- **Open question:** Which parts of this draft should become active in the first independently versioned release?

--- a/EPISTEMOLOGY.md
+++ b/EPISTEMOLOGY.md
@@ -1,0 +1,64 @@
+---
+schema: aether.architecture-document/v1
+id: organization-github-epistemology
+title: Ego Hygiene .github Epistemology
+kind: architecture-document
+version: 0.1.0
+status: provisional
+owners:
+  - egohygiene
+created: 2026-08-19
+updated: 2026-08-19
+governed_by:
+  - architecture-epistemology
+depends_on:
+  - organization-github-purpose
+  - organization-github-principles
+related:
+  - organization-github-vision
+  - organization-github-pillars
+  - organization-github-manifesto
+  - organization-github-ai-constitution
+supersedes: []
+---
+
+# Ego Hygiene .github Epistemology
+
+## Scope
+
+This document governs how Ego Hygiene .github classifies claims, evidence, provenance, confidence, conflict, and revision. It does not dictate which technical conclusion must be accepted.
+
+## Claim states
+
+| State | Meaning |
+| --- | --- |
+| Observed | Directly supported by repository or runtime evidence |
+| Decided | Accepted through the repository governance process |
+| Inferred | Reasoned from evidence but not directly observed |
+| Proposed | Recommended future direction not yet accepted |
+| Assumed | Necessary working premise awaiting evidence |
+| Unverified | Plausible claim that has not been checked |
+| Open question | A known gap requiring investigation or choice |
+
+## Evidence order
+
+1. Reproducible tests, schemas, generated artifacts, and runtime observations.
+2. Accepted decisions and versioned specifications.
+3. Current source and configuration.
+4. Maintainer documentation and issue history.
+5. Inference and recommendation, labeled with uncertainty.
+
+## Provenance and conflict
+
+Claims should identify their source closely enough to be rechecked. Conflicting evidence remains visible until the canonical owner resolves it; recency alone does not automatically establish truth.
+
+## Revision
+
+Material claims are revised when stronger evidence appears, their source changes, or an accepted decision supersedes them. Historical decision context is preserved rather than rewritten.
+
+## Evidence and uncertainty
+
+- **Observed:** The repository README establishes the intended boundary as the organization-facing GitHub profile, public defaults, contribution entry points, and fallback coordination surface; significant implementation remains incomplete.
+- **Decided for this draft:** The repository owns the bounded concern described here and participates through versioned contracts.
+- **Proposed:** Target systems and later roadmap phases remain proposals until accepted and implemented.
+- **Open question:** Which parts of this draft should become active in the first independently versioned release?

--- a/FOUNDATIONS.md
+++ b/FOUNDATIONS.md
@@ -1,0 +1,58 @@
+---
+schema: aether.architecture-document/v1
+id: organization-github-foundations
+title: Ego Hygiene .github Foundations
+kind: architecture-document
+version: 0.1.0
+status: provisional
+owners:
+  - egohygiene
+created: 2026-08-19
+updated: 2026-08-19
+governed_by:
+  - architecture-foundations
+depends_on:
+  - organization-github-purpose
+  - organization-github-principles
+  - organization-github-epistemology
+related:
+  - organization-github-vision
+  - organization-github-pillars
+  - organization-github-manifesto
+  - organization-github-ai-constitution
+supersedes: []
+---
+
+# Ego Hygiene .github Foundations
+
+## Foundational assumptions
+
+- The repository owns one bounded concern and integrates through explicit contracts.
+- Human authority, privacy, safety, provenance, and accessibility are architectural constraints.
+- Canonical source is distinguishable from generated output and transient state.
+- Observed, desired, proposed, and accepted states remain distinguishable.
+- Validation evidence must be reproducible closely enough to support review.
+- Standalone usefulness is preserved even when the wider organization adds value.
+- Self-hosting and portability are supported without pretending external compute, storage, domains, or providers are free.
+
+## Enduring constraints
+
+- Do not make mutable default branches or unpublished internal APIs cross-repository dependencies.
+- Do not put secrets, private source material, or provider credentials in generated architecture or distribution artifacts.
+- Do not let convenience erase approval, rollback, or provenance at consequential boundaries.
+- Do not claim cross-platform, self-hosted, or production support beyond verified evidence.
+
+## Trust boundaries
+
+Repository source, generated artifacts, local state, external providers, organization automation, and user-controlled infrastructure are distinct trust zones. Every crossing requires an explicit data, authority, and failure contract.
+
+## Success properties
+
+The foundation is healthy when Organization discovery, Community health defaults, Coordination fallback, Canonical routing remain independently testable and their ownership is clear.
+
+## Evidence and uncertainty
+
+- **Observed:** The repository README establishes the intended boundary as the organization-facing GitHub profile, public defaults, contribution entry points, and fallback coordination surface; significant implementation remains incomplete.
+- **Decided for this draft:** The repository owns the bounded concern described here and participates through versioned contracts.
+- **Proposed:** Target systems and later roadmap phases remain proposals until accepted and implemented.
+- **Open question:** Which parts of this draft should become active in the first independently versioned release?

--- a/MANIFESTO.md
+++ b/MANIFESTO.md
@@ -1,0 +1,58 @@
+---
+schema: aether.architecture-document/v1
+id: organization-github-manifesto
+title: Ego Hygiene .github Manifesto
+kind: architecture-document
+version: 0.1.0
+status: provisional
+owners:
+  - egohygiene
+created: 2026-08-19
+updated: 2026-08-19
+governed_by:
+  - architecture-manifesto
+depends_on:
+  - organization-github-purpose
+  - organization-github-vision
+  - organization-github-principles
+  - organization-github-pillars
+related:
+  - organization-github-epistemology
+  - organization-github-ai-constitution
+  - organization-github-ontology
+  - organization-github-personal-model
+supersedes: []
+---
+
+# Ego Hygiene .github Manifesto
+
+## Declaration
+
+We believe give every GitHub visitor and contributor a coherent, discoverable entrance into the Ego Hygiene organization is worth doing carefully, openly, and with respect for the people affected by the system.
+
+## We stand for
+
+- Public entry points stay simple: make the commitment visible in behavior, not only prose.
+- Link to canonical ownership: make the commitment visible in behavior, not only prose.
+- Defaults must be safe: make the commitment visible in behavior, not only prose.
+- GitHub limitations are explicit: make the commitment visible in behavior, not only prose.
+- Organization voice remains welcoming: make the commitment visible in behavior, not only prose.
+
+## We reject
+
+- concealed authority and irreversible surprise;
+- lock-in disguised as convenience;
+- claims of certainty without evidence;
+- automation that erases human context;
+- architecture that centralizes ownership merely because it is easier today.
+
+## Commitment
+
+We will keep Ego Hygiene .github independently understandable, honestly incomplete when evidence is missing, and open to revision when better evidence or lived experience contradicts current assumptions.
+
+## Evidence and uncertainty
+
+- **Observed:** The repository README establishes the intended boundary as the organization-facing GitHub profile, public defaults, contribution entry points, and fallback coordination surface; significant implementation remains incomplete.
+- **Decided for this draft:** The repository owns the bounded concern described here and participates through versioned contracts.
+- **Proposed:** Target systems and later roadmap phases remain proposals until accepted and implemented.
+- **Open question:** Which parts of this draft should become active in the first independently versioned release?

--- a/META.md
+++ b/META.md
@@ -1,0 +1,113 @@
+---
+schema: aether.architecture-document/v1
+id: organization-github-meta
+title: Ego Hygiene .github Meta
+kind: architecture-document
+version: 0.1.0
+status: provisional
+owners:
+  - egohygiene
+created: 2026-08-19
+updated: 2026-08-19
+governed_by:
+  - architecture-meta
+depends_on:
+  - organization-github-epistemology
+  - organization-github-ai-constitution
+related:
+  - organization-github-purpose
+  - organization-github-vision
+  - organization-github-principles
+  - organization-github-pillars
+supersedes: []
+---
+
+# Ego Hygiene .github Meta Architecture
+
+## Architecture-system overview
+
+Ego Hygiene .github's architecture is an 18-document graph materialized from the Aether architecture specifications. Each document owns one bounded concern. This index maps ownership and relationships without replacing the documents themselves.
+
+## Document inventory
+
+| Artifact | Path | Category | Status | Governing specification | Upstream dependencies |
+| --- | --- | --- | --- | --- | --- |
+| organization-github-purpose | [PURPOSE.md](PURPOSE.md) | Identity | provisional | architecture-purpose | — |
+| organization-github-vision | [VISION.md](VISION.md) | Identity | provisional | architecture-vision | organization-github-purpose |
+| organization-github-principles | [PRINCIPLES.md](PRINCIPLES.md) | Identity | provisional | architecture-principles | organization-github-purpose, organization-github-vision |
+| organization-github-pillars | [PILLARS.md](PILLARS.md) | Identity | provisional | architecture-pillars | organization-github-purpose, organization-github-vision, organization-github-principles |
+| organization-github-manifesto | [MANIFESTO.md](MANIFESTO.md) | Identity | provisional | architecture-manifesto | organization-github-purpose, organization-github-vision, organization-github-principles, organization-github-pillars |
+| organization-github-epistemology | [EPISTEMOLOGY.md](EPISTEMOLOGY.md) | Meta | provisional | architecture-epistemology | organization-github-purpose, organization-github-principles |
+| organization-github-ai-constitution | [AI_CONSTITUTION.md](AI_CONSTITUTION.md) | Meta | provisional | architecture-ai-constitution | organization-github-purpose, organization-github-vision, organization-github-principles, organization-github-epistemology |
+| organization-github-ontology | [ONTOLOGY.md](ONTOLOGY.md) | Domain | provisional | architecture-ontology | organization-github-purpose, organization-github-vision, organization-github-principles, organization-github-epistemology |
+| organization-github-personal-model | [PERSONAL_MODEL.md](PERSONAL_MODEL.md) | Domain | provisional | architecture-personal-model | organization-github-purpose, organization-github-vision, organization-github-principles, organization-github-epistemology, organization-github-ontology |
+| organization-github-foundations | [FOUNDATIONS.md](FOUNDATIONS.md) | Foundation | provisional | architecture-foundations | organization-github-purpose, organization-github-principles, organization-github-epistemology |
+| organization-github-system | [SYSTEM.md](SYSTEM.md) | Foundation | provisional | architecture-system | organization-github-foundations, organization-github-ontology |
+| organization-github-architecture | [ARCHITECTURE.md](ARCHITECTURE.md) | Foundation | provisional | architecture-architecture | organization-github-foundations, organization-github-system |
+| organization-github-methodology | [METHODOLOGY.md](METHODOLOGY.md) | Foundation | provisional | architecture-methodology | organization-github-principles, organization-github-epistemology, organization-github-ai-constitution, organization-github-foundations, organization-github-architecture |
+| organization-github-design | [DESIGN.md](DESIGN.md) | Experience | provisional | architecture-design | organization-github-purpose, organization-github-vision, organization-github-principles, organization-github-personal-model |
+| organization-github-design-system | [DESIGN_SYSTEM.md](DESIGN_SYSTEM.md) | Experience | provisional | architecture-design-system | organization-github-personal-model, organization-github-design |
+| organization-github-decisions | [DECISIONS.md](DECISIONS.md) | Governance | provisional | architecture-decisions | organization-github-principles, organization-github-epistemology, organization-github-foundations, organization-github-system, organization-github-architecture |
+| organization-github-roadmap | [ROADMAP.md](ROADMAP.md) | Foundation | provisional | architecture-roadmap | organization-github-vision, organization-github-pillars, organization-github-architecture, organization-github-decisions |
+| organization-github-meta | [META.md](META.md) | Meta | provisional | architecture-meta | organization-github-epistemology, organization-github-ai-constitution |
+
+## Relationship graph
+
+```mermaid
+flowchart TD
+  PURPOSE --> VISION --> PRINCIPLES --> PILLARS --> MANIFESTO
+  PURPOSE --> EPISTEMOLOGY --> AI[AI Constitution]
+  PRINCIPLES --> EPISTEMOLOGY
+  EPISTEMOLOGY --> ONTOLOGY --> PERSONAL[Personal Model]
+  PRINCIPLES --> FOUNDATIONS
+  EPISTEMOLOGY --> FOUNDATIONS
+  FOUNDATIONS --> SYSTEM --> ARCHITECTURE --> METHODOLOGY
+  PERSONAL --> DESIGN --> DS[Design System]
+  ARCHITECTURE --> DECISIONS --> ROADMAP
+  PILLARS --> ROADMAP
+  AI --> META
+  EPISTEMOLOGY --> META
+```
+
+## Ownership map
+
+- Identity documents own why the repository exists, its desired future, decision heuristics, strategic capabilities, and public commitments.
+- Meta documents own knowledge integrity, AI authority, and navigation of this document system.
+- Domain documents own canonical concepts and bounded human assumptions.
+- Foundation documents own invariants, logical systems, structure, working method, and strategic evolution.
+- Experience documents own intended experience and reusable semantic design language.
+- Governance owns accepted architectural decisions and historical lineage.
+
+## Reading order
+
+1. PURPOSE, VISION, and PRINCIPLES.
+2. EPISTEMOLOGY and ONTOLOGY.
+3. FOUNDATIONS, SYSTEM, and ARCHITECTURE.
+4. PERSONAL_MODEL, DESIGN, and DESIGN_SYSTEM when evaluating human-facing surfaces.
+5. AI_CONSTITUTION before delegating consequential work.
+6. DECISIONS and ROADMAP for accepted constraints and evolution.
+
+## Authoring order
+
+Follow the dependency graph from purpose through identity and evidence, then domain and foundations, experience, governance, roadmap, and finally this META index.
+
+## Lifecycle and validation
+
+All documents begin as provisional and require human review before becoming active. Validation covers frontmatter, stable identifiers, links, graph acyclicity, ownership boundaries, evidence labels, Markdown structure, and agreement with repository reality.
+
+## Change propagation
+
+A material upstream change triggers review of every downstream node. Implementation changes first update the owning specification or decision when they alter durable behavior; META changes whenever inventory or relationships change.
+
+## Gaps and omissions
+
+- No document in this set is intentionally omitted because Ego Hygiene .github has repository, automation, human, AI, and public or documentation surfaces that justify the complete reference set.
+- Target systems remain provisional where implementation evidence is absent.
+- Repository-local schemas and automated graph validation should be added or connected to Aether in a later conformance pass.
+
+## Evidence and uncertainty
+
+- **Observed:** The repository README establishes the intended boundary as the organization-facing GitHub profile, public defaults, contribution entry points, and fallback coordination surface; significant implementation remains incomplete.
+- **Decided for this draft:** The repository owns the bounded concern described here and participates through versioned contracts.
+- **Proposed:** Target systems and later roadmap phases remain proposals until accepted and implemented.
+- **Open question:** Which parts of this draft should become active in the first independently versioned release?

--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -1,0 +1,66 @@
+---
+schema: aether.architecture-document/v1
+id: organization-github-methodology
+title: Ego Hygiene .github Methodology
+kind: architecture-document
+version: 0.1.0
+status: provisional
+owners:
+  - egohygiene
+created: 2026-08-19
+updated: 2026-08-19
+governed_by:
+  - architecture-methodology
+depends_on:
+  - organization-github-principles
+  - organization-github-epistemology
+  - organization-github-ai-constitution
+  - organization-github-foundations
+  - organization-github-architecture
+related:
+  - organization-github-purpose
+  - organization-github-vision
+  - organization-github-pillars
+  - organization-github-manifesto
+supersedes: []
+---
+
+# Ego Hygiene .github Methodology
+
+## Working method
+
+Ego Hygiene .github combines specification-driven, schema-driven, and test-driven development in one evidence loop:
+
+> Discover → Model → Specify → Plan → Test → Implement → Validate → Review → Integrate → Reflect
+
+## Method contracts
+
+1. **Discover evidence:** inspect current source, runtime behavior, users, risks, and neighboring ownership.
+2. **Model the domain:** update ontology and boundaries before encoding unstable terminology.
+3. **Specify behavior:** define inputs, outputs, invariants, authority, failures, and acceptance criteria.
+4. **Define schemas:** make durable machine boundaries independently validatable.
+5. **Write tests:** cover happy paths, boundaries, failures, compatibility, and safety properties.
+6. **Implement narrowly:** change only the owning system and adapters required by the specification.
+7. **Validate evidence:** run deterministic checks and preserve important results.
+8. **Review impact:** inspect architecture, security, privacy, accessibility, operations, and downstream consumers.
+9. **Integrate and reflect:** publish through the defined lifecycle and feed lessons into decisions and roadmap.
+
+## Quality gates
+
+- Structural and schema validation.
+- Unit, integration, contract, and end-to-end tests appropriate to the change.
+- Security, dependency, licensing, privacy, and secret checks.
+- Documentation and architecture consistency.
+- Reproducible build or artifact verification.
+- Human approval at external, destructive, billing, production, or publication boundaries.
+
+## AI collaboration
+
+Agents may accelerate discovery, drafting, implementation, and verification within explicit scope. They preserve provenance, report failures honestly, and do not convert recommendations into accepted decisions.
+
+## Evidence and uncertainty
+
+- **Observed:** The repository README establishes the intended boundary as the organization-facing GitHub profile, public defaults, contribution entry points, and fallback coordination surface; significant implementation remains incomplete.
+- **Decided for this draft:** The repository owns the bounded concern described here and participates through versioned contracts.
+- **Proposed:** Target systems and later roadmap phases remain proposals until accepted and implemented.
+- **Open question:** Which parts of this draft should become active in the first independently versioned release?

--- a/ONTOLOGY.md
+++ b/ONTOLOGY.md
@@ -1,0 +1,66 @@
+---
+schema: aether.architecture-document/v1
+id: organization-github-ontology
+title: Ego Hygiene .github Ontology
+kind: architecture-document
+version: 0.1.0
+status: provisional
+owners:
+  - egohygiene
+created: 2026-08-19
+updated: 2026-08-19
+governed_by:
+  - architecture-ontology
+depends_on:
+  - organization-github-purpose
+  - organization-github-vision
+  - organization-github-principles
+  - organization-github-epistemology
+related:
+  - organization-github-pillars
+  - organization-github-manifesto
+  - organization-github-ai-constitution
+  - organization-github-personal-model
+supersedes: []
+---
+
+# Ego Hygiene .github Ontology
+
+## Domain scope
+
+Ego Hygiene .github models the concepts needed for give every GitHub visitor and contributor a coherent, discoverable entrance into the Ego Hygiene organization. The ontology names conceptual entities and relationships; it is not a source-code class model, API schema, or database design.
+
+## Canonical concepts
+
+| Concept | Meaning |
+| --- | --- |
+| Organization profile | A canonical concept in the Ego Hygiene .github domain whose exact fields belong to specifications or schemas, not this ontology. |
+| Community health file | A canonical concept in the Ego Hygiene .github domain whose exact fields belong to specifications or schemas, not this ontology. |
+| Issue template | A canonical concept in the Ego Hygiene .github domain whose exact fields belong to specifications or schemas, not this ontology. |
+| Pull Request template | A canonical concept in the Ego Hygiene .github domain whose exact fields belong to specifications or schemas, not this ontology. |
+| Public default | A canonical concept in the Ego Hygiene .github domain whose exact fields belong to specifications or schemas, not this ontology. |
+| Coordination issue | A canonical concept in the Ego Hygiene .github domain whose exact fields belong to specifications or schemas, not this ontology. |
+| Canonical link | A canonical concept in the Ego Hygiene .github domain whose exact fields belong to specifications or schemas, not this ontology. |
+
+## Core relationships
+
+- A repository or person provides source context to one or more domain artifacts.
+- A specification constrains how an artifact is interpreted or produced.
+- A plan separates proposed action from execution.
+- Evidence supports a claim; a decision authorizes a durable direction.
+- Provenance connects derived artifacts to their inputs and processing context.
+- A consumer integrates through an explicit interface rather than internal structure.
+
+## Boundaries
+
+- Conceptual identity is distinct from filesystem path, database identifier, or display label.
+- Observed state is distinct from desired state.
+- Proposed relationships are not accepted facts.
+- Neighboring repositories retain ownership of their domain concepts.
+
+## Evidence and uncertainty
+
+- **Observed:** The repository README establishes the intended boundary as the organization-facing GitHub profile, public defaults, contribution entry points, and fallback coordination surface; significant implementation remains incomplete.
+- **Decided for this draft:** The repository owns the bounded concern described here and participates through versioned contracts.
+- **Proposed:** Target systems and later roadmap phases remain proposals until accepted and implemented.
+- **Open question:** Which parts of this draft should become active in the first independently versioned release?

--- a/PERSONAL_MODEL.md
+++ b/PERSONAL_MODEL.md
@@ -1,0 +1,64 @@
+---
+schema: aether.architecture-document/v1
+id: organization-github-personal-model
+title: Ego Hygiene .github Personal Model
+kind: architecture-document
+version: 0.1.0
+status: provisional
+owners:
+  - egohygiene
+created: 2026-08-19
+updated: 2026-08-19
+governed_by:
+  - architecture-personal-model
+depends_on:
+  - organization-github-purpose
+  - organization-github-vision
+  - organization-github-principles
+  - organization-github-epistemology
+  - organization-github-ontology
+related:
+  - organization-github-pillars
+  - organization-github-manifesto
+  - organization-github-ai-constitution
+  - organization-github-foundations
+supersedes: []
+---
+
+# Ego Hygiene .github Personal Model
+
+## Purpose
+
+Ego Hygiene .github is designed for and operated by people even when it is primarily a library or automation surface. This document makes its limited human assumptions explicit; it is not a persona catalog, diagnosis, identity model, or prediction engine.
+
+## People in scope
+
+- contributors
+- maintainers
+- users exploring the organization
+- GitHub-native automation
+
+Maintainers, contributors, reviewers, and people indirectly affected by generated or published outputs are also in scope.
+
+## Human assumptions
+
+- Attention, time, technical knowledge, sensory tolerance, and risk tolerance vary.
+- People may arrive under stress, with incomplete context, or using assistive technology.
+- A person's files, history, choices, or metrics do not fully represent them.
+- Consent to inspect is not automatically consent to mutate, publish, infer, or retain.
+- People need meaningful recovery paths when systems fail.
+
+## Agency and consent boundaries
+
+Consequential operations require understandable scope, current authorization, and an appropriate preview or confirmation. Personal inference must be optional, purpose-limited, labeled, correctable, and removable.
+
+## Accessibility and dignity
+
+Primary journeys should remain keyboard-accessible, screen-reader legible, reduced-motion compatible, and understandable without expert vocabulary. Error messages describe recovery without blame.
+
+## Evidence and uncertainty
+
+- **Observed:** The repository README establishes the intended boundary as the organization-facing GitHub profile, public defaults, contribution entry points, and fallback coordination surface; significant implementation remains incomplete.
+- **Decided for this draft:** The repository owns the bounded concern described here and participates through versioned contracts.
+- **Proposed:** Target systems and later roadmap phases remain proposals until accepted and implemented.
+- **Open question:** Which parts of this draft should become active in the first independently versioned release?

--- a/PILLARS.md
+++ b/PILLARS.md
@@ -1,0 +1,57 @@
+---
+schema: aether.architecture-document/v1
+id: organization-github-pillars
+title: Ego Hygiene .github Pillars
+kind: architecture-document
+version: 0.1.0
+status: provisional
+owners:
+  - egohygiene
+created: 2026-08-19
+updated: 2026-08-19
+governed_by:
+  - architecture-pillars
+depends_on:
+  - organization-github-purpose
+  - organization-github-vision
+  - organization-github-principles
+related:
+  - organization-github-manifesto
+  - organization-github-epistemology
+  - organization-github-ai-constitution
+  - organization-github-ontology
+supersedes: []
+---
+
+# Ego Hygiene .github Pillars
+
+## Role
+
+The pillars are enduring strategic capabilities, not projects, repositories, components, or roadmap phases.
+
+## Pillar 1: Organization discovery
+
+This capability must remain healthy for Ego Hygiene .github to fulfill its purpose. Its health should be visible through versioned contracts, tests or review evidence, documentation, and clear ownership.
+
+## Pillar 2: Community health defaults
+
+This capability must remain healthy for Ego Hygiene .github to fulfill its purpose. Its health should be visible through versioned contracts, tests or review evidence, documentation, and clear ownership.
+
+## Pillar 3: Coordination fallback
+
+This capability must remain healthy for Ego Hygiene .github to fulfill its purpose. Its health should be visible through versioned contracts, tests or review evidence, documentation, and clear ownership.
+
+## Pillar 4: Canonical routing
+
+This capability must remain healthy for Ego Hygiene .github to fulfill its purpose. Its health should be visible through versioned contracts, tests or review evidence, documentation, and clear ownership.
+
+## Balance
+
+No pillar is complete in isolation. Delivery that weakens trust, ownership, accessibility, or evidence does not count as durable progress.
+
+## Evidence and uncertainty
+
+- **Observed:** The repository README establishes the intended boundary as the organization-facing GitHub profile, public defaults, contribution entry points, and fallback coordination surface; significant implementation remains incomplete.
+- **Decided for this draft:** The repository owns the bounded concern described here and participates through versioned contracts.
+- **Proposed:** Target systems and later roadmap phases remain proposals until accepted and implemented.
+- **Open question:** Which parts of this draft should become active in the first independently versioned release?

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -1,0 +1,70 @@
+---
+schema: aether.architecture-document/v1
+id: organization-github-principles
+title: Ego Hygiene .github Principles
+kind: architecture-document
+version: 0.1.0
+status: provisional
+owners:
+  - egohygiene
+created: 2026-08-19
+updated: 2026-08-19
+governed_by:
+  - architecture-principles
+depends_on:
+  - organization-github-purpose
+  - organization-github-vision
+related:
+  - organization-github-pillars
+  - organization-github-manifesto
+  - organization-github-epistemology
+  - organization-github-ai-constitution
+supersedes: []
+---
+
+# Ego Hygiene .github Principles
+
+## Purpose
+
+These principles guide decisions when multiple valid options exist. They do not replace policy, accepted decisions, specifications, or implementation standards.
+
+## 1. Public entry points stay simple
+
+**Guidance:** Prefer choices that make this principle observable in contracts, behavior, and evidence.
+
+**Trade-off:** Accept some additional explicitness and validation when it prevents hidden coupling, lost provenance, or irreversible surprise.
+
+## 2. Link to canonical ownership
+
+**Guidance:** Prefer choices that make this principle observable in contracts, behavior, and evidence.
+
+**Trade-off:** Accept some additional explicitness and validation when it prevents hidden coupling, lost provenance, or irreversible surprise.
+
+## 3. Defaults must be safe
+
+**Guidance:** Prefer choices that make this principle observable in contracts, behavior, and evidence.
+
+**Trade-off:** Accept some additional explicitness and validation when it prevents hidden coupling, lost provenance, or irreversible surprise.
+
+## 4. GitHub limitations are explicit
+
+**Guidance:** Prefer choices that make this principle observable in contracts, behavior, and evidence.
+
+**Trade-off:** Accept some additional explicitness and validation when it prevents hidden coupling, lost provenance, or irreversible surprise.
+
+## 5. Organization voice remains welcoming
+
+**Guidance:** Prefer choices that make this principle observable in contracts, behavior, and evidence.
+
+**Trade-off:** Accept some additional explicitness and validation when it prevents hidden coupling, lost provenance, or irreversible surprise.
+
+## Precedence and exceptions
+
+Safety, human agency, privacy, and explicit policy take precedence over convenience and speed. Exceptions require a recorded rationale, bounded duration when temporary, validation evidence, and a review trigger.
+
+## Evidence and uncertainty
+
+- **Observed:** The repository README establishes the intended boundary as the organization-facing GitHub profile, public defaults, contribution entry points, and fallback coordination surface; significant implementation remains incomplete.
+- **Decided for this draft:** The repository owns the bounded concern described here and participates through versioned contracts.
+- **Proposed:** Target systems and later roadmap phases remain proposals until accepted and implemented.
+- **Open question:** Which parts of this draft should become active in the first independently versioned release?

--- a/PURPOSE.md
+++ b/PURPOSE.md
@@ -1,0 +1,59 @@
+---
+schema: aether.architecture-document/v1
+id: organization-github-purpose
+title: Ego Hygiene .github Purpose
+kind: architecture-document
+version: 0.1.0
+status: provisional
+owners:
+  - egohygiene
+created: 2026-08-19
+updated: 2026-08-19
+governed_by:
+  - architecture-purpose
+depends_on:
+  []
+related:
+  - organization-github-vision
+  - organization-github-principles
+  - organization-github-pillars
+  - organization-github-manifesto
+supersedes: []
+---
+
+# Ego Hygiene .github Purpose
+
+## Purpose statement
+
+Ego Hygiene .github exists to give every GitHub visitor and contributor a coherent, discoverable entrance into the Ego Hygiene organization.
+
+## Need
+
+GitHub supports only a bounded set of organization-wide files, so the supported public defaults need explicit ownership and links to canonical policy elsewhere.
+
+## Beneficiaries
+
+- contributors
+- maintainers
+- users exploring the organization
+- GitHub-native automation
+
+## Enduring value
+
+The enduring value is a trustworthy, portable capability that remains useful when its implementation, delivery channel, or surrounding platform changes.
+
+## Scope boundaries
+
+Ego Hygiene .github owns the organization-facing GitHub profile, public defaults, contribution entry points, and fallback coordination surface. It does not absorb neighboring repositories, treat temporary implementation choices as purpose, or claim authority beyond its explicit contracts.
+
+## Evidence and uncertainty
+
+- **Observed:** The repository README establishes the intended boundary as the organization-facing GitHub profile, public defaults, contribution entry points, and fallback coordination surface; significant implementation remains incomplete.
+- **Decided for this draft:** The repository owns the bounded concern described here and participates through versioned contracts.
+- **Proposed:** Target systems and later roadmap phases remain proposals until accepted and implemented.
+- **Open question:** Which parts of this draft should become active in the first independently versioned release?
+
+## Open questions
+
+- Which beneficiary needs require direct research before this document can become active?
+- Which current features are incidental and should remain outside the enduring purpose?

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,98 @@
+---
+schema: aether.architecture-document/v1
+id: organization-github-roadmap
+title: Ego Hygiene .github Roadmap
+kind: architecture-document
+version: 0.1.0
+status: provisional
+owners:
+  - egohygiene
+created: 2026-08-19
+updated: 2026-08-19
+governed_by:
+  - architecture-roadmap
+depends_on:
+  - organization-github-vision
+  - organization-github-pillars
+  - organization-github-architecture
+  - organization-github-decisions
+related:
+  - organization-github-purpose
+  - organization-github-principles
+  - organization-github-manifesto
+  - organization-github-epistemology
+supersedes: []
+---
+
+# Ego Hygiene .github Roadmap
+
+## Strategic context
+
+This roadmap describes capability evolution, not promised dates or an issue queue. Sequence follows architecture dependencies and may change when evidence or risk changes.
+
+## Phase 1: Clarify supported GitHub surfaces
+
+**Outcome:** A bounded capability advances from documented intent to validated, independently usable behavior.
+
+**Exit signals:**
+
+- The owning contract and acceptance criteria are versioned.
+- Implementation and documentation agree.
+- Relevant tests and safety checks pass.
+- Downstream consumers and migration impact are understood.
+- Remaining uncertainty is visible.
+
+## Phase 2: Route every concern to a canonical owner
+
+**Outcome:** A bounded capability advances from documented intent to validated, independently usable behavior.
+
+**Exit signals:**
+
+- The owning contract and acceptance criteria are versioned.
+- Implementation and documentation agree.
+- Relevant tests and safety checks pass.
+- Downstream consumers and migration impact are understood.
+- Remaining uncertainty is visible.
+
+## Phase 3: Automate safe projections
+
+**Outcome:** A bounded capability advances from documented intent to validated, independently usable behavior.
+
+**Exit signals:**
+
+- The owning contract and acceptance criteria are versioned.
+- Implementation and documentation agree.
+- Relevant tests and safety checks pass.
+- Downstream consumers and migration impact are understood.
+- Remaining uncertainty is visible.
+
+## Phase 4: Measure organization onboarding quality
+
+**Outcome:** A bounded capability advances from documented intent to validated, independently usable behavior.
+
+**Exit signals:**
+
+- The owning contract and acceptance criteria are versioned.
+- Implementation and documentation agree.
+- Relevant tests and safety checks pass.
+- Downstream consumers and migration impact are understood.
+- Remaining uncertainty is visible.
+
+## Cross-cutting tracks
+
+- Security, privacy, accessibility, licensing, and provenance.
+- Documentation, architecture portals, examples, and onboarding.
+- Packaging, release, compatibility, and self-hosting.
+- Organization integration through explicit contracts.
+- Observatory evidence and Pace conformance when those systems exist.
+
+## Deferred direction
+
+Optional managed services, enterprise controls, marketplaces, and the conversational organization compiler remain later architecture work. Current choices should preserve portability and avoid foreclosing them.
+
+## Evidence and uncertainty
+
+- **Observed:** The repository README establishes the intended boundary as the organization-facing GitHub profile, public defaults, contribution entry points, and fallback coordination surface; significant implementation remains incomplete.
+- **Decided for this draft:** The repository owns the bounded concern described here and participates through versioned contracts.
+- **Proposed:** Target systems and later roadmap phases remain proposals until accepted and implemented.
+- **Open question:** Which parts of this draft should become active in the first independently versioned release?

--- a/SYSTEM.md
+++ b/SYSTEM.md
@@ -1,0 +1,63 @@
+---
+schema: aether.architecture-document/v1
+id: organization-github-system
+title: Ego Hygiene .github System
+kind: architecture-document
+version: 0.1.0
+status: provisional
+owners:
+  - egohygiene
+created: 2026-08-19
+updated: 2026-08-19
+governed_by:
+  - architecture-system
+depends_on:
+  - organization-github-foundations
+  - organization-github-ontology
+related:
+  - organization-github-purpose
+  - organization-github-vision
+  - organization-github-principles
+  - organization-github-pillars
+supersedes: []
+---
+
+# Ego Hygiene .github System
+
+## Purpose and scope
+
+This document identifies Ego Hygiene .github's logical systems and responsibilities. It answers what the major systems do; [ARCHITECTURE.md](ARCHITECTURE.md) owns their structural organization and dependency rules.
+
+## System inventory
+
+| System | State | Responsibility |
+| --- | --- | --- |
+| Organization profile | Target | Owns its bounded portion of the organization-facing GitHub profile, public defaults, contribution entry points, and fallback coordination surface; exposes explicit inputs, outputs, failure states, and evidence. |
+| Community health defaults | Target | Owns its bounded portion of the organization-facing GitHub profile, public defaults, contribution entry points, and fallback coordination surface; exposes explicit inputs, outputs, failure states, and evidence. |
+| Issue and pull-request intake | Target | Owns its bounded portion of the organization-facing GitHub profile, public defaults, contribution entry points, and fallback coordination surface; exposes explicit inputs, outputs, failure states, and evidence. |
+| Agent instruction projection | Target | Owns its bounded portion of the organization-facing GitHub profile, public defaults, contribution entry points, and fallback coordination surface; exposes explicit inputs, outputs, failure states, and evidence. |
+| Coordination queue | Target | Owns its bounded portion of the organization-facing GitHub profile, public defaults, contribution entry points, and fallback coordination surface; exposes explicit inputs, outputs, failure states, and evidence. |
+
+## External systems
+
+- Hygiene control plane
+- Empathy baseline
+- Relay workflows
+- Aether agent contracts
+
+External systems are integrations, not hidden implementation units. Each requires version, authentication, availability, data, error, and replacement boundaries appropriate to its risk.
+
+## System interactions
+
+Inputs enter through an adapter or validated contract, move through domain systems, produce artifacts and diagnostics, and leave through a stable interface. Evidence flows back to validation, review, and future decisions.
+
+## Failure model
+
+Systems fail closed at destructive, publication, privacy, and security boundaries. Partial results identify coverage and remain distinguishable from complete success.
+
+## Evidence and uncertainty
+
+- **Observed:** The repository README establishes the intended boundary as the organization-facing GitHub profile, public defaults, contribution entry points, and fallback coordination surface; significant implementation remains incomplete.
+- **Decided for this draft:** The repository owns the bounded concern described here and participates through versioned contracts.
+- **Proposed:** Target systems and later roadmap phases remain proposals until accepted and implemented.
+- **Open question:** Which parts of this draft should become active in the first independently versioned release?

--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,58 @@
+---
+schema: aether.architecture-document/v1
+id: organization-github-vision
+title: Ego Hygiene .github Vision
+kind: architecture-document
+version: 0.1.0
+status: provisional
+owners:
+  - egohygiene
+created: 2026-08-19
+updated: 2026-08-19
+governed_by:
+  - architecture-vision
+depends_on:
+  - organization-github-purpose
+related:
+  - organization-github-principles
+  - organization-github-pillars
+  - organization-github-manifesto
+  - organization-github-epistemology
+supersedes: []
+---
+
+# Ego Hygiene .github Vision
+
+## Vision statement
+
+GitHub-native organization surfaces remain lightweight, welcoming, and consistently connected to the canonical control plane.
+
+## Desired future state
+
+- The core capability is independently usable and documented.
+- Interfaces are versioned, inspectable, and replaceable.
+- Local, self-hosted, and managed contexts can compose the capability without hidden lock-in.
+- People can understand consequential behavior before approving it.
+- Organization integrations strengthen the standalone product rather than making it dependent on the suite.
+
+## Intended transformation
+
+The project moves its domain from fragmented, implicit, and manually coordinated behavior toward explicit contracts, reusable automation, and evidence-backed operation.
+
+## Anti-vision
+
+a shadow policy repository that duplicates Hygiene, Empathy, Relay, or Aether.
+
+## Directional signals
+
+- A first-time user can explain the boundary after reading the architecture.
+- A consumer can integrate through a stable public contract.
+- A maintainer can reproduce and validate a release.
+- A contributor can distinguish implemented, proposed, and unavailable capabilities.
+
+## Evidence and uncertainty
+
+- **Observed:** The repository README establishes the intended boundary as the organization-facing GitHub profile, public defaults, contribution entry points, and fallback coordination surface; significant implementation remains incomplete.
+- **Decided for this draft:** The repository owns the bounded concern described here and participates through versioned contracts.
+- **Proposed:** Target systems and later roadmap phases remain proposals until accepted and implemented.
+- **Open question:** Which parts of this draft should become active in the first independently versioned release?


### PR DESCRIPTION
## Summary

- adds the complete 18-document Aether architecture reference set
- defines .github's public purpose, human and AI authority, domain and routing boundaries, system structure, experience language, decisions, and roadmap
- preserves independent product and canonical-owner boundaries instead of centralizing the whole organization in one web or GitHub repository
- includes Mermaid views and a complete META inventory

## Architecture source

Follows [egohygiene/aether#42](https://github.com/egohygiene/aether/pull/42) and the Empathy reference corpus.

## Validation

- 18 canonical documents with stable `organization-github-*` IDs
- resolved, acyclic dependencies
- one H1 per file; relative links resolve
- META inventories every file and identifier

## Review notes

Documentation only. No routes, deployments, commerce providers, checkout, organization defaults, templates, or external services are changed.