### PR TITLE
Define organization issue intake and routing

### DIFF
--- a/.github/ISSUE_TEMPLATE/organization-work.yml
+++ b/.github/ISSUE_TEMPLATE/organization-work.yml
@@ -1,0 +1,76 @@
+name: Organization work
+description: Route organization-level, cross-repository, or not-yet-owned work.
+title: "[org]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template when work is genuinely organization-level, crosses repository boundaries, or does not yet have a durable owner. If one repository clearly owns the implementation, open the issue there instead.
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Outcome
+      description: What observable result should exist when this work is complete?
+    validations:
+      required: true
+
+  - type: input
+    id: owner
+    attributes:
+      label: Owning repository or routing state
+      description: Name the durable owner, or write "needs-routing" when ownership is genuinely unresolved.
+      placeholder: egohygiene/hygiene
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: Describe the bounded work. Keep implementation details in the owning repository when this is an umbrella issue.
+    validations:
+      required: true
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: Link prerequisite issues, repositories, contracts, or decisions. Write "None" when independent.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Provide reviewable completion criteria.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: security
+    attributes:
+      label: Security, privacy, and destructive-action considerations
+      description: Identify secrets, personal/private data, signing, infrastructure, billing, destructive migrations, publication, or other trust boundaries. Write "None identified" when appropriate.
+    validations:
+      required: true
+
+  - type: textarea
+    id: implementation
+    attributes:
+      label: Linked implementation issues
+      description: For cross-repository work, link bounded implementation issues instead of duplicating their checklists here.
+
+  - type: checkboxes
+    id: routing_confirmation
+    attributes:
+      label: Routing confirmation
+      options:
+        - label: I checked whether an existing repository already owns this capability.
+          required: true
+        - label: This issue does not contain credentials, tokens, private keys, or other secrets.
+          required: true

--- a/docs/issue-routing.md
+++ b/docs/issue-routing.md
@@ -1,0 +1,89 @@
+# Organization Issue Routing
+
+The `egohygiene/.github` repository is the organization-level intake and coordination surface. It is not the default implementation repository for work that already has a durable owner.
+
+## Routing rule
+
+Route work to the narrowest durable owner that can complete it without copying another repository's implementation.
+
+Use `.github` when work is genuinely organization-facing or when ownership is not yet known. Once an owner is established, keep the umbrella issue here only when cross-repository coordination remains useful and link to the implementation issue instead of duplicating its checklist.
+
+## Intake states
+
+| State | Meaning | Next action |
+| --- | --- | --- |
+| `needs-routing` | No durable owner is established yet. | Identify the capability and candidate owners. |
+| `routed` | An implementation owner is known. | Link the owning issue/repository. |
+| `cross-repo` | Multiple repositories must coordinate through explicit contracts. | Keep an umbrella issue and link bounded implementation issues. |
+| `blocked` | A dependency prevents useful implementation. | Record the dependency and unblock condition. |
+| `ready` | Scope, owner, dependencies, and acceptance criteria are sufficient for implementation. | Execute in the owning repository. |
+
+These names describe the intended taxonomy. Label creation/synchronization should be performed by the organization automation owned by Relay rather than hand-maintained independently in every repository.
+
+## Stable label taxonomy
+
+The organization taxonomy should remain deliberately small.
+
+### Priority
+
+- `priority:p0` — correctness, security, or data-integrity blocker.
+- `priority:p1` — required foundation or near-term release work.
+- `priority:p2` — important planned capability.
+- `priority:p3` — research, exploration, or later direction.
+
+### Type
+
+- `type:architecture`
+- `type:feature`
+- `type:bug`
+- `type:documentation`
+- `type:research`
+- `type:maintenance`
+
+### Area
+
+Use `area:<domain>` only for stable domains that improve filtering. Do not create a label for every component or repository.
+
+### Coordination
+
+- `cross-repo`
+- `needs-routing`
+- `blocked`
+- `ready`
+
+Repository-specific overlays may add labels, but must not redefine organization label semantics.
+
+## Umbrella issues
+
+An umbrella issue owns coordination, not duplicated implementation.
+
+It should contain:
+
+- the organization-level outcome;
+- the owning repositories;
+- dependency edges;
+- links to implementation issues;
+- integration acceptance criteria.
+
+Implementation details belong in the repository that owns them. Closing an implementation issue does not automatically close the umbrella issue until the cross-repository outcome is verified.
+
+## Routing examples
+
+| Request | Owner |
+| --- | --- |
+| Organization profile/community defaults | `.github` |
+| Canonical architecture/policy/catalog | `hygiene` |
+| Repository baseline/template contract | `empathy` |
+| Repository materialization | `holon` |
+| AI artifacts and provider projections | `aether` |
+| Reusable GitHub Actions | `relay` |
+| Lint semantics | `egolint` |
+| Development environments | `realm` |
+| Portable shell/workstation behavior | `mantle` |
+| Fleet convergence | `pace` |
+| Fleet visibility/evidence | `observatory` |
+| Unknown experimental capability | `.github` for routing, then `sanctuary` when incubation is appropriate and available |
+
+## Security and destructive work
+
+Issues involving secrets, signing, production infrastructure, billing, destructive migration, personal/private data, or external publication must state the trust boundary and required human approval. Do not place credentials or sensitive values in issues.


### PR DESCRIPTION
Closes #8

## Summary

- documents `.github` as the organization intake/coordination fallback rather than a universal implementation owner
- defines the transition from `needs-routing` to a durable repository owner
- defines a deliberately small organization label taxonomy for priority, type, area, and coordination state
- defines umbrella issues as coordination surfaces that link bounded implementation issues instead of duplicating them
- adds a structured organization-work issue form requiring outcome, owner/routing state, dependencies, acceptance criteria, and security/trust-boundary review
- documents representative routing across Hygiene, Empathy, Holon, Aether, Relay, Egolint, Realm, Mantle, Pace, Observatory, and future Sanctuary incubation

## Architecture

This PR keeps label synchronization mechanics out of `.github`; Relay remains the automation owner. Repository-specific label overlays may extend but must not redefine organization semantics.

## Validation

- issue form is valid YAML by inspection and uses GitHub Issue Forms supported field types
- no credentials or external mutations are introduced
- no implementation is copied from sibling repositories

## Follow-up

Relay should consume the taxonomy for safe label synchronization. Hygiene can reference the routing contract from organization architecture/catalog work.