### PR TITLE
docs(roadmap): reconcile the 2026-08-24 execution graph

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -167,7 +167,7 @@ issues: []
 ### Roadmap-to-issue handoff
 
 - A step is complete only when its exit criteria and required evidence are satisfied; commit count never determines progress.
-- Ready or planned steps without an issue are candidates for the private, duplicate-aware roadmap.issue-plan.json dry run.
+- Ready steps without an issue are candidates for the private, duplicate-aware roadmap.issue-plan.json dry run. Planned steps remain preview-only unless a reviewer explicitly opts them in with issue_policy: propose.
 - Issue creation or reconciliation requires human approval or an explicitly authorized Pace operation and returns issue references through a reviewable roadmap pull request.
 - Pull requests and commits should include Roadmap-Step: <ID>; historical evidence may be linked through existing issue and pull-request relationships.
 - Public rendering uses only allowlisted build-time evidence and never places a GitHub token or private issue plan in the browser artifact.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ status: provisional
 owners:
   - egohygiene
 created: 2026-08-19
-updated: 2026-08-19
+updated: 2026-08-24
 governed_by:
   - architecture-roadmap
 depends_on:
@@ -25,6 +25,154 @@ supersedes: []
 ---
 
 # Ego Hygiene .github Roadmap
+
+<!-- BEGIN ROADMAP EXECUTION SNAPSHOT -->
+<!-- roadmap-manifest
+schema: hygiene.roadmap/v1alpha1
+repository: egohygiene/.github
+visibility: public
+publication: central
+route: /roadmap/.github/
+updated: 2026-08-24
+-->
+## 2026-08-24 execution snapshot
+
+> This evidence-reconciled snapshot is the issue-generation and visual-roadmap handoff. The longer-horizon strategy below remains canonical context; generated HTML, JSON, progress, issue plans, and commit lists are projections.
+
+**Lifecycle:** incubating foundation  
+**Current gate:** Finish the label and routing policy tracked in issue #8, then prove the organization defaults in a consumer repository.  
+**North-star outcome:** A thin, trusted set of organization defaults that makes contribution, security, and intake behavior predictable without hiding repository-owned policy.
+
+### Visual roadmap publication
+
+**Mode:** `central`  
+**Route:** `/roadmap/.github/`  
+**Current publication evidence:** Organization-wide GitHub defaults; no Pages publication observed.
+
+Publish the public-safe projection through egohygiene.io at /roadmap/.github/. This repository owns intent and acceptance evidence; it does not add a second site deployment.
+
+### Quest line
+
+<!-- roadmap-step
+id: ORG-Q01
+status: complete
+depends_on: []
+issues: []
+-->
+#### ORG-Q01 — Land the trust and intake baseline
+
+**State:** `complete`  
+**Depends on:** None
+
+**Outcome:** Organization profile and intake mechanisms provide a usable shared starting point.
+
+**Exit criteria:**
+
+- [x] The shared profile and intake artifacts are present on the default branch.
+- [x] Their intended organization-wide scope is documented.
+
+**Current evidence:**
+
+- Merged PR #14 at 0b83d5270d0b.
+- Merged PR #16 at 2c04a1f55cc0.
+
+<!-- roadmap-step
+id: ORG-Q02
+status: active
+depends_on: [ORG-Q01]
+issues: [8]
+-->
+#### ORG-Q02 — Complete label and routing policy
+
+**State:** `active`  
+**Depends on:** `ORG-Q01`
+
+**Outcome:** New work is labeled and routed consistently across the organization.
+
+**Exit criteria:**
+
+- [ ] Issue #8 has an accepted label taxonomy and routing contract.
+- [ ] At least one repository demonstrates the policy without repository-specific ambiguity.
+
+**Current evidence:**
+
+- Issue #8 remains unfinished as of 2026-08-24.
+
+<!-- roadmap-step
+id: ORG-Q03
+status: ready
+depends_on: [ORG-Q02]
+issues: []
+-->
+#### ORG-Q03 — Validate inherited community files
+
+**State:** `ready`  
+**Depends on:** `ORG-Q02`
+
+**Outcome:** Repositories can tell which community files they inherit and which they must own.
+
+**Exit criteria:**
+
+- [ ] An automated check covers all intended inherited files.
+- [ ] Exceptions and private-repository behavior are documented.
+
+**Current evidence:**
+
+- No organization-level validation workflow was observed.
+
+<!-- roadmap-step
+id: ORG-Q04
+status: planned
+depends_on: [ORG-Q03]
+issues: []
+-->
+#### ORG-Q04 — Define the boundary with Hygiene
+
+**State:** `planned`  
+**Depends on:** `ORG-Q03`
+
+**Outcome:** Human-facing defaults stay here while machine-readable portfolio policy is owned by Hygiene.
+
+**Exit criteria:**
+
+- [ ] Ownership is stated in both repositories.
+- [ ] No policy is authoritative in two places.
+
+**Current evidence:**
+
+- Hygiene is the proposed canonical machine-readable organization definition.
+
+<!-- roadmap-step
+id: ORG-Q05
+status: planned
+depends_on: [ORG-Q03, ORG-Q04]
+issues: []
+-->
+#### ORG-Q05 — Publish a verified organization-default release
+
+**State:** `planned`  
+**Depends on:** `ORG-Q03`, `ORG-Q04`
+
+**Outcome:** A dated, evidence-backed checkpoint makes changes to shared defaults auditable.
+
+**Exit criteria:**
+
+- [ ] All lightweight validation is green.
+- [ ] The checkpoint links the policy changes and consumer proof.
+
+**Current evidence:**
+
+- No CI or release publication was observed.
+
+### Roadmap-to-issue handoff
+
+- A step is complete only when its exit criteria and required evidence are satisfied; commit count never determines progress.
+- Ready or planned steps without an issue are candidates for the private, duplicate-aware roadmap.issue-plan.json dry run.
+- Issue creation or reconciliation requires human approval or an explicitly authorized Pace operation and returns issue references through a reviewable roadmap pull request.
+- Pull requests and commits should include Roadmap-Step: <ID>; historical evidence may be linked through existing issue and pull-request relationships.
+- Public rendering uses only allowlisted build-time evidence and never places a GitHub token or private issue plan in the browser artifact.
+
+<!-- END ROADMAP EXECUTION SNAPSHOT -->
 
 ## Strategic context
 


### PR DESCRIPTION
## What this proposes

- adds an evidence-reconciled 5-step execution snapshot with stable IDs, states, dependencies, outcomes, exit criteria, and current evidence;
- preserves the repository's existing long-horizon roadmap;
- records visual-roadmap publication as `central` at `/roadmap/.github/`;
- establishes the private, duplicate-aware handoff from ready roadmap steps to future GitHub issue plans.

**Current gate:** Finish the label and routing policy tracked in issue #8, then prove the organization defaults in a consumer repository.

## Why this is a draft

This truth update is reviewable now. Merge should wait for the proposed `hygiene.roadmap/v1alpha1` contract and Egolint validation path so the metadata is accepted once and adopted consistently.

## Safety boundaries

- documentation only;
- no issues are created, closed, or relabeled;
- no workflow, token, Pages setting, or deployment is changed;
- commit volume is not used as progress;
- private issue plans are excluded from public site output.

Roadmap-Step: ORG-Q02